### PR TITLE
Add dashboard metrics and remove unused import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import About from './pages/About';
 import Admin from './pages/Admin';
 import AdminLogin from './pages/AdminLogin';
 import AdminProfile from './pages/AdminProfile';
-import Setup from './pages/Setup';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   return (
@@ -28,6 +28,7 @@ function App() {
               <Route path="/admin" element={<Admin />} />
               <Route path="/admin-login" element={<AdminLogin />} />
               <Route path="/admin-profile" element={<AdminProfile />} />
+              <Route path="/dashboard" element={<Dashboard />} />
             </Routes>
             <Toaster position="top-center" richColors />
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,8 @@ const Header = () => {
     { path: '/contact', label: t.nav.contact },
     { path: '/drivers', label: t.nav.driverRegistration },
     { path: '/companies', label: t.nav.companyRegistration },
-    { path: '/admin', label: t.nav.admin }
+    { path: '/admin', label: t.nav.admin },
+    { path: '/dashboard', label: t.nav.dashboard }
   ];
 
   const handleLogout = () => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { Users, Building2 } from 'lucide-react';
+import Header from '../components/Header';
+import { useLanguage } from '../contexts/LanguageContext';
+import { supabase } from '../integrations/supabase/client';
+
+const Dashboard = () => {
+  const { t, language } = useLanguage();
+  const isRTL = language === 'ar' || language === 'ur';
+
+  const [driverCount, setDriverCount] = useState<number | null>(null);
+  const [companyCount, setCompanyCount] = useState<number | null>(null);
+  const [showDrivers, setShowDrivers] = useState(true);
+  const [showCompanies, setShowCompanies] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('dashboard_prefs');
+    if (saved) {
+      try {
+        const prefs = JSON.parse(saved);
+        if (typeof prefs.showDrivers === 'boolean') setShowDrivers(prefs.showDrivers);
+        if (typeof prefs.showCompanies === 'boolean') setShowCompanies(prefs.showCompanies);
+      } catch {
+        /* ignore */
+      }
+    }
+    fetchCounts();
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(
+      'dashboard_prefs',
+      JSON.stringify({ showDrivers, showCompanies })
+    );
+  }, [showDrivers, showCompanies]);
+
+  const fetchCounts = async () => {
+    try {
+      const [driversRes, companiesRes] = await Promise.all([
+        supabase.from('drivers').select('*', { count: 'exact', head: true }),
+        supabase.from('companies').select('*', { count: 'exact', head: true })
+      ]);
+      if (driversRes.count !== null) setDriverCount(driversRes.count);
+      if (companiesRes.count !== null) setCompanyCount(companiesRes.count);
+    } catch (error) {
+      console.error('Failed to fetch counts', error);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <div className="container mx-auto px-4 py-8 space-y-8">
+        <h1 className="text-2xl font-bold">{t.dashboard.title}</h1>
+        <div className="flex gap-6">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="border rounded"
+              checked={showDrivers}
+              onChange={(e) => setShowDrivers(e.target.checked)}
+            />
+            {t.dashboard.showDrivers}
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="border rounded"
+              checked={showCompanies}
+              onChange={(e) => setShowCompanies(e.target.checked)}
+            />
+            {t.dashboard.showCompanies}
+          </label>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {showDrivers && (
+            <div className="p-6 bg-white rounded-lg shadow flex items-center justify-between">
+              <div>
+                <div className="text-sm text-gray-500">{t.dashboard.drivers}</div>
+                <div className="text-3xl font-bold">
+                  {driverCount !== null ? driverCount : '—'}
+                </div>
+              </div>
+              <Users size={32} className="text-primary" />
+            </div>
+          )}
+          {showCompanies && (
+            <div className="p-6 bg-white rounded-lg shadow flex items-center justify-between">
+              <div>
+                <div className="text-sm text-gray-500">{t.dashboard.companies}</div>
+                <div className="text-3xl font-bold">
+                  {companyCount !== null ? companyCount : '—'}
+                </div>
+              </div>
+              <Building2 size={32} className="text-primary" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -9,6 +9,7 @@ export interface Translation {
     driverRegistration: string;
     companyRegistration: string;
     admin: string;
+    dashboard: string;
   };
   hero: {
     title: string;
@@ -65,6 +66,13 @@ export interface Translation {
   about: {
     title: string;
     content: string;
+  };
+  dashboard: {
+    title: string;
+    drivers: string;
+    companies: string;
+    showDrivers: string;
+    showCompanies: string;
   };
   admin: {
     title: string;

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -8,7 +8,8 @@ export const translations: Record<Language, Translation> = {
       contact: 'اتصل بنا',
       driverRegistration: 'تسجيل السائقين',
       companyRegistration: 'تسجيل الشركات',
-      admin: 'الإدارة'
+      admin: 'الإدارة',
+      dashboard: 'لوحة القيادة'
     },
     hero: {
       title: 'Mile Truck - وسيط شحن موثوق',
@@ -65,6 +66,13 @@ export const translations: Record<Language, Translation> = {
     about: {
       title: 'عن شركة Mile Truck',
       content: 'نحن شركة وساطة شحن موثوقة نقدم خدمات النقل والشحن للسائقين والشركات. نهدف إلى ربط أصحاب الشاحنات بفرص النقل المناسبة لزيادة العائد وتطوير الأعمال.'
+    },
+    dashboard: {
+      title: 'لوحة القيادة',
+      drivers: 'عدد السائقين',
+      companies: 'عدد الشركات',
+      showDrivers: 'إظهار عدد السائقين',
+      showCompanies: 'إظهار عدد الشركات'
     },
     admin: {
       title: 'لوحة الإدارة',
@@ -143,7 +151,8 @@ export const translations: Record<Language, Translation> = {
       contact: 'Contact',
       driverRegistration: 'Driver Registration',
       companyRegistration: 'Company Registration',
-      admin: 'Admin'
+      admin: 'Admin',
+      dashboard: 'Dashboard'
     },
     hero: {
       title: 'Mile Truck - Trusted Shipping Broker',
@@ -200,6 +209,13 @@ export const translations: Record<Language, Translation> = {
     about: {
       title: 'About Mile Truck',
       content: 'We are a trusted shipping brokerage company providing transportation and shipping services for drivers and companies. We aim to connect truck owners with suitable transportation opportunities to increase revenue and develop business.'
+    },
+    dashboard: {
+      title: 'Dashboard',
+      drivers: 'Drivers Count',
+      companies: 'Companies Count',
+      showDrivers: 'Show drivers count',
+      showCompanies: 'Show companies count'
     },
     admin: {
       title: 'Admin Panel',
@@ -278,7 +294,8 @@ export const translations: Record<Language, Translation> = {
       contact: 'رابطہ کریں',
       driverRegistration: 'ڈرائیور رجسٹریشن',
       companyRegistration: 'کمپنی رجسٹریشن',
-      admin: 'ایڈمن'
+      admin: 'ایڈمن',
+      dashboard: 'ڈیش بورڈ'
     },
     hero: {
       title: 'Mile Truck - قابل اعتماد شپنگ بروکر',
@@ -335,6 +352,13 @@ export const translations: Record<Language, Translation> = {
     about: {
       title: 'Mile Truck کے بارے میں',
       content: 'ہم ایک قابل اعتماد شپنگ بروکریج کمپنی ہیں جو ڈرائیورز اور کمپنیوں کے لیے نقل و حمل اور شپنگ کی خدمات فراہم کرتی ہے۔ ہمارا مقصد ٹرک مالکان کو مناسب نقل و حمل کے مواقع سے جوڑنا ہے تاکہ آمدنی بڑھائی جا سکے اور کاروبار کو ترقی دی جا سکے۔'
+    },
+    dashboard: {
+      title: 'ڈیش بورڈ',
+      drivers: 'ڈرائیورز کی تعداد',
+      companies: 'کمپنیوں کی تعداد',
+      showDrivers: 'ڈرائیورز کی تعداد دکھائیں',
+      showCompanies: 'کمپنیوں کی تعداد دکھائیں'
     },
     admin: {
       title: 'ایڈمن پینل',
@@ -413,7 +437,8 @@ export const translations: Record<Language, Translation> = {
       contact: 'संपर्क करें',
       driverRegistration: 'ड्राइवर पंजीकरण',
       companyRegistration: 'कंपनी पंजीकरण',
-      admin: 'एडमिन'
+      admin: 'एडमिन',
+      dashboard: 'डैशबोर्ड'
     },
     hero: {
       title: 'Mile Truck - विश्वसनीय शिपिंग ब्रोकर',
@@ -470,6 +495,13 @@ export const translations: Record<Language, Translation> = {
     about: {
       title: 'Mile Truck के बारे में',
       content: 'हम एक विश्वसनीय शिपिंग ब्रोकरेज कंपनी हैं जो ड्राइवरों और कंपनियों के लिए परिवहन और शिपिंग सेवाएं प्रदान करती है। हमारा लक्ष्य ट्रक मालिकों को उपयुक्त परिवहन के अवसरों से जोड़ना है ताकि आय बढ़ाई जा सके और व्यवसाय को विकसित किया जा सके।'
+    },
+    dashboard: {
+      title: 'डैशबोर्ड',
+      drivers: 'ड्राइवरों की संख्या',
+      companies: 'कंपनियों की संख्या',
+      showDrivers: 'ड्राइवर गिनती दिखाएं',
+      showCompanies: 'कंपनी गिनती दिखाएं'
     },
     admin: {
       title: 'एडमिन पैनल',


### PR DESCRIPTION
## Summary
- clean up unused `Setup` import from `App.tsx`
- add new `Dashboard` page showing driver and company counts
- persist dashboard preferences in local storage
- update navigation to include dashboard link
- extend language types and translations for dashboard strings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf38422f0832682a70d43a123082c